### PR TITLE
feat: multi-workspace support and branch suggestions dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the "github-workflow-runner" extension will be documented in this file.
 
+## [Unreleased]
+
+### ✨ New Features
+
+- **Multi-Workspace Support:** The extension now works correctly in VS Code multi-root workspaces.
+  - A **workspace switcher** appears inside the Git Context box when two or more workspace folders are open — click the repo name to pick a different folder from the dropdown
+  - Workflows, branches, repository config, and Git context all reload automatically when switching workspaces
+  - Only GitHub-backed folders are shown with their `owner/repo` label; non-GitHub folders fall back to their folder name
+
+- **Branch Suggestions Dropdown:** The Branch field now shows a native autocomplete list when a workflow is selected.
+  - Suggestions include the default branch, your current local branch, and recently used branches (deduplicated and ordered by relevance)
+  - Still a free-text field — type any branch name or pick from the list
+
 ## [1.5.1] - 2025-12-30
 
 ### ✨ New Features

--- a/README.md
+++ b/README.md
@@ -25,11 +25,15 @@ Dispatch workflows with dynamic inputs, monitor runs in real-time, save presets,
 
 Stop switching between VS Code and GitHub's web UI. Dispatch workflows, monitor runs, and view logs without breaking your development flow.
 
+### 🗂️ **Multi-Workspace Support** _(New)_
+
+Works seamlessly in VS Code multi-root workspaces. A workspace switcher appears inside the **Git Context** box — click the repo name to switch between folders. Workflows, branches, and repository config reload automatically for the selected workspace.
+
 ### 🎯 **Smart & Dynamic**
 
 - **Auto-generated forms** from your workflow YAML — no manual configuration
 - **Intelligent input recovery** — rerun workflows with prefilled inputs from previous runs
-- **Branch auto-detection** — automatically uses your current Git branch
+- **Branch auto-detection** — automatically uses your current Git branch, with a suggestion dropdown showing your default and recent branches _(New)_
 - **Smart File Input** — enhanced input fields with file path autocomplete, content extraction, and favorites
 
 ### 📁 **Smart File Input** _(New in v1.3.0)_
@@ -90,10 +94,11 @@ Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/item
 ### 3️⃣ **Dispatch Your First Workflow**
 
 1. Open a repository with GitHub Actions workflows
-2. Select a workflow from the dropdown (only `workflow_dispatch` workflows are shown)
-3. Fill in any required inputs
-4. Select a branch (defaults to your current branch)
-5. Click **"Dispatch Workflow"** 🚀
+2. If using a **multi-root workspace**, select the target repo from the switcher in the Git Context box
+3. Select a workflow from the dropdown (only `workflow_dispatch` workflows are shown)
+4. Fill in any required inputs
+5. Type a branch or pick one from the suggestion list (default branch, current branch, and recent branches are shown)
+6. Click **"Dispatch Workflow"** 🚀
 
 ### 4️⃣ **Monitor Workflow Runs**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "github-workflow-runner",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "github-workflow-runner",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "Apache-2.0",
       "dependencies": {
         "adm-zip": "^0.5.16",

--- a/src/providers/sidebar-provider.ts
+++ b/src/providers/sidebar-provider.ts
@@ -20,6 +20,7 @@ import type {
   WorkflowDefinition,
 } from '../types/workflow-types';
 import { isAuthenticated, signOut } from '../utils/authenticate';
+import { setActiveWorkspacePath } from '../utils/active-workspace';
 import { getConfig } from '../utils/config';
 import { FavoritesManager } from '../utils/favorites-manager';
 import { getNonce } from '../utils/get-nonce';
@@ -240,6 +241,10 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
       case 'setActiveWorkspace': {
         const folderPath = message.data as string | undefined;
         this._activeWorkspacePath = folderPath || undefined;
+        // Share the selection so other parts of the extension (e.g. the
+        // Workflow Runs panel) resolve the repository against the chosen
+        // workspace instead of falling back to the first workspace folder.
+        setActiveWorkspacePath(this._activeWorkspacePath);
         // Reload all data for the newly selected workspace
         await this._reloadExtensionData();
         break;

--- a/src/providers/sidebar-provider.ts
+++ b/src/providers/sidebar-provider.ts
@@ -35,6 +35,7 @@ import {
 import { Storage } from '../utils/storage';
 import { TokenManager } from '../utils/token-manager';
 import { getAllWorkflowDefinitions, getWorkflowDefinition } from '../utils/workflow-parser';
+import { getAllWorkspaceRepos } from '../utils/git-operations';
 import { WorkflowRunsPanel } from './workflow-runs-panel';
 import type { WorkflowRunsProvider } from './workflow-runs-provider';
 
@@ -44,6 +45,8 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
   private _isWebviewReady = false;
   private _readyPromise: Promise<void> | null = null;
   private _readyResolve: (() => void) | null = null;
+  /** Path of the workspace folder currently selected in the repo switcher. */
+  private _activeWorkspacePath: string | undefined = undefined;
 
   constructor(private readonly _extensionUri: vscode.Uri) {}
 
@@ -229,6 +232,18 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
       case 'getUserInfo':
         await this._sendUserInfo();
         break;
+
+      case 'getWorkspaceFolders':
+        await this._sendWorkspaceFolders();
+        break;
+
+      case 'setActiveWorkspace': {
+        const folderPath = message.data as string | undefined;
+        this._activeWorkspacePath = folderPath || undefined;
+        // Reload all data for the newly selected workspace
+        await this._reloadExtensionData();
+        break;
+      }
 
       case 'getRepositoryConfig':
         await this._sendRepositoryConfig();
@@ -471,7 +486,7 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
       console.log('[SidebarProvider] Reloading extension data...');
 
       // Refresh and store the new Git context
-      const newContext = await refreshGitContext();
+      const newContext = await refreshGitContext(this._activeWorkspacePath);
       console.log('[SidebarProvider] New Git context:', newContext);
 
       // Re-send repository config
@@ -526,19 +541,19 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
    */
   private async _openWorkflowFile(filePath: string) {
     try {
-      const repoInfo = await getRepositoryInfo();
+      const repoInfo = await getRepositoryInfo(this._activeWorkspacePath);
       if (!repoInfo) {
         vscode.window.showErrorMessage('Could not get repository information');
         return;
       }
 
-      const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-      if (!workspaceFolder) {
+      const rootPath = this._activeWorkspacePath ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+      if (!rootPath) {
         vscode.window.showErrorMessage('No workspace folder open');
         return;
       }
 
-      const fullPath = vscode.Uri.joinPath(workspaceFolder.uri, filePath);
+      const fullPath = vscode.Uri.joinPath(vscode.Uri.file(rootPath), filePath);
 
       try {
         await vscode.workspace.fs.stat(fullPath);
@@ -564,7 +579,10 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
    */
   private async _sendWorkflows() {
     const config = getConfig();
-    const workflows = await getAllWorkflowDefinitions(config.workflows.excludePatterns);
+    const workflows = await getAllWorkflowDefinitions(
+      config.workflows.excludePatterns,
+      this._activeWorkspacePath
+    );
 
     this._view?.webview.postMessage({
       type: 'getWorkflows',
@@ -577,7 +595,7 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
    * Send workflow schema to webview
    */
   private async _sendWorkflowSchema(filename: string) {
-    const workflow = await getWorkflowDefinition(filename);
+    const workflow = await getWorkflowDefinition(filename, this._activeWorkspacePath);
 
     this._view?.webview.postMessage({
       type: 'getWorkflowSchema',
@@ -661,7 +679,10 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
   }) {
     try {
       // Validate Git context before any GitHub API operation
-      const isValidContext = await ensureGitContextValidOrWarn('dispatchWorkflow');
+      const isValidContext = await ensureGitContextValidOrWarn(
+        'dispatchWorkflow',
+        this._activeWorkspacePath
+      );
       if (!isValidContext) {
         this._view?.webview.postMessage({
           type: 'gitContextMismatch',
@@ -672,8 +693,8 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
       }
 
       const config = getConfig();
-      const repoConfig = await getRepositoryConfig();
-      const workflow = await getWorkflowDefinition(data.workflowFilename);
+      const repoConfig = await getRepositoryConfig(this._activeWorkspacePath);
+      const workflow = await getWorkflowDefinition(data.workflowFilename, this._activeWorkspacePath);
 
       if (!workflow) {
         throw new Error('Workflow not found');
@@ -795,7 +816,7 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
    * Send current branch to webview
    */
   private async _sendCurrentBranch() {
-    const branch = await getCurrentBranch();
+    const branch = await getCurrentBranch(this._activeWorkspacePath);
 
     this._view?.webview.postMessage({
       type: 'getCurrentBranch',
@@ -810,7 +831,7 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
    */
   private async _fetchDefaultBranchFromGitHub(): Promise<string | undefined> {
     try {
-      const repoConfig = await getRepositoryConfig();
+      const repoConfig = await getRepositoryConfig(this._activeWorkspacePath);
 
       const owner = repoConfig.owner?.trim();
       const name = repoConfig.name?.trim();
@@ -884,7 +905,7 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
    * Send recent branches to webview
    */
   private async _sendRecentBranches() {
-    const branches = await getRecentBranches();
+    const branches = await getRecentBranches(10, this._activeWorkspacePath);
 
     this._view?.webview.postMessage({
       type: 'getRecentBranches',
@@ -1058,11 +1079,34 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
   }
 
   /**
+   * Send all workspace folders with their GitHub repo info to the webview.
+   */
+  private async _sendWorkspaceFolders() {
+    try {
+      const workspaces = await getAllWorkspaceRepos();
+      this._view?.webview.postMessage({
+        type: 'getWorkspaceFolders',
+        success: true,
+        data: {
+          workspaces,
+          activeWorkspacePath: this._activeWorkspacePath ?? null,
+        },
+      });
+    } catch (error) {
+      this._view?.webview.postMessage({
+        type: 'getWorkspaceFolders',
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to get workspace folders',
+      });
+    }
+  }
+
+  /**
    * Send repository config to webview
    */
   private async _sendRepositoryConfig() {
     try {
-      const repoConfig = await getRepositoryConfig();
+      const repoConfig = await getRepositoryConfig(this._activeWorkspacePath);
 
       this._view?.webview.postMessage({
         type: 'getRepositoryConfig',

--- a/src/providers/workflow-runs-panel.ts
+++ b/src/providers/workflow-runs-panel.ts
@@ -22,6 +22,7 @@ import {
   getWorkflowRuns,
   rerunWorkflow,
 } from '../api/workflow-monitor';
+import { getActiveWorkspacePath } from '../utils/active-workspace';
 import { getConfig } from '../utils/config';
 import { getNonce } from '../utils/get-nonce';
 import { ensureGitContextValidOrWarn } from '../utils/git-context-validation';
@@ -4189,14 +4190,16 @@ export class WorkflowRunsPanel {
         return;
       }
 
-      // Construct the full path to the workflow file
-      const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-      if (!workspaceFolder) {
+      // Construct the full path to the workflow file, scoped to the active
+      // workspace so multi-root setups open the file from the selected repo.
+      const rootPath =
+        getActiveWorkspacePath() ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+      if (!rootPath) {
         vscode.window.showErrorMessage('No workspace folder open');
         return;
       }
 
-      const fullPath = vscode.Uri.joinPath(workspaceFolder.uri, filePath);
+      const fullPath = vscode.Uri.joinPath(vscode.Uri.file(rootPath), filePath);
 
       // Check if file exists
       try {

--- a/src/types/workflow-types.ts
+++ b/src/types/workflow-types.ts
@@ -370,6 +370,23 @@ export interface GitRepositoryInfo {
 }
 
 /**
+ * Summary of a workspace folder and its associated GitHub repository (if any).
+ * Used by the multi-workspace repo switcher.
+ */
+export interface WorkspaceRepoInfo {
+  /** VS Code workspace folder display name */
+  folderName: string;
+  /** Absolute path to the workspace folder */
+  folderPath: string;
+  /** GitHub repository owner (null if not a GitHub repo) */
+  owner: string | null;
+  /** GitHub repository name (null if not a GitHub repo) */
+  repoName: string | null;
+  /** Whether this folder is a GitHub-backed git repo */
+  isGitHub: boolean;
+}
+
+/**
  * GitHub user information
  */
 export interface GitHubUserInfo {
@@ -802,6 +819,8 @@ export type WebviewMessageType =
   | 'checkAuth'
   | 'signOut'
   | 'getUserInfo'
+  | 'getWorkspaceFolders'
+  | 'setActiveWorkspace'
   | 'getRepositoryConfig'
   | 'setRepositoryConfig'
   | 'resetRepositoryConfig'

--- a/src/utils/active-workspace.ts
+++ b/src/utils/active-workspace.ts
@@ -1,0 +1,29 @@
+/**
+ * Active workspace tracking for multi-root (multi-workspace) setups.
+ *
+ * The sidebar lets the user pick which workspace folder / repository to operate
+ * on. That selection lives in the sidebar webview, but several other parts of
+ * the extension (most notably the Workflow Runs panel) resolve the repository
+ * by falling back to the first workspace folder. This module holds the selected
+ * workspace path so those fallbacks target the chosen repository instead of
+ * always using `workspaceFolders[0]`.
+ *
+ * An explicit `workspacePath` argument always takes precedence; this value is
+ * only consulted as the default when no explicit path is provided.
+ */
+let activeWorkspacePath: string | undefined;
+
+/**
+ * Set the currently selected workspace folder path (undefined to clear and fall
+ * back to the first workspace folder).
+ */
+export function setActiveWorkspacePath(workspacePath: string | undefined): void {
+  activeWorkspacePath = workspacePath || undefined;
+}
+
+/**
+ * Get the currently selected workspace folder path, if any.
+ */
+export function getActiveWorkspacePath(): string | undefined {
+  return activeWorkspacePath;
+}

--- a/src/utils/git-context-validation.ts
+++ b/src/utils/git-context-validation.ts
@@ -40,8 +40,8 @@ export interface GitContextValidationResult {
 /**
  * Build a GitContextSnapshot from the current workspace Git repository.
  */
-async function buildCurrentSnapshot(): Promise<GitContextSnapshot | null> {
-  const repoInfo = await getRepositoryInfo();
+async function buildCurrentSnapshot(workspacePath?: string): Promise<GitContextSnapshot | null> {
+  const repoInfo = await getRepositoryInfo(workspacePath);
   if (!repoInfo) {
     return null;
   }
@@ -58,8 +58,10 @@ async function buildCurrentSnapshot(): Promise<GitContextSnapshot | null> {
  * Validate that the current Git repository and branch match the ones stored in
  * extension state from the last validation/reload.
  */
-export async function validateGitContextForGitHubOperation(): Promise<GitContextValidationResult> {
-  const current = await buildCurrentSnapshot();
+export async function validateGitContextForGitHubOperation(
+  workspacePath?: string
+): Promise<GitContextValidationResult> {
+  const current = await buildCurrentSnapshot(workspacePath);
 
   if (!current) {
     return {
@@ -115,8 +117,10 @@ export async function validateGitContextForGitHubOperation(): Promise<GitContext
  * Force-refresh the stored Git context to the current workspace state.
  * Call this when the user explicitly reloads extension data.
  */
-export async function refreshGitContext(): Promise<GitContextSnapshot | null> {
-  const current = await buildCurrentSnapshot();
+export async function refreshGitContext(
+  workspacePath?: string
+): Promise<GitContextSnapshot | null> {
+  const current = await buildCurrentSnapshot(workspacePath);
   if (current) {
     await Storage.setLastValidatedGitContext(current);
   } else {
@@ -128,16 +132,21 @@ export async function refreshGitContext(): Promise<GitContextSnapshot | null> {
 /**
  * Get the current Git context without validation.
  */
-export async function getCurrentGitContext(): Promise<GitContextSnapshot | null> {
-  return buildCurrentSnapshot();
+export async function getCurrentGitContext(
+  workspacePath?: string
+): Promise<GitContextSnapshot | null> {
+  return buildCurrentSnapshot(workspacePath);
 }
 
 /**
  * Validate Git context and, when invalid, show a standard warning message.
  * Returns true when it is safe to proceed with GitHub API operations.
  */
-export async function ensureGitContextValidOrWarn(source?: string): Promise<boolean> {
-  const result = await validateGitContextForGitHubOperation();
+export async function ensureGitContextValidOrWarn(
+  source?: string,
+  workspacePath?: string
+): Promise<boolean> {
+  const result = await validateGitContextForGitHubOperation(workspacePath);
 
   if (result.ok) {
     return true;

--- a/src/utils/git-operations.ts
+++ b/src/utils/git-operations.ts
@@ -3,21 +3,37 @@
  */
 import { execSync } from 'child_process';
 import * as vscode from 'vscode';
-import type { GitRepositoryInfo } from '../types/workflow-types';
+import type { GitRepositoryInfo, WorkspaceRepoInfo } from '../types/workflow-types';
+
+/**
+ * Resolve the working directory for git operations.
+ * If workspacePath is provided, uses it directly; otherwise falls back to the
+ * first workspace folder.
+ */
+function resolveWorkspaceCwd(workspacePath?: string): string | undefined {
+  if (workspacePath) {
+    return workspacePath;
+  }
+  const folders = vscode.workspace.workspaceFolders;
+  return folders && folders.length > 0 ? folders[0].uri.fsPath : undefined;
+}
 
 /**
  * Get current Git branch using VS Code Git API
  */
-export async function getCurrentBranch(): Promise<string | undefined> {
+export async function getCurrentBranch(workspacePath?: string): Promise<string | undefined> {
   try {
-    // Try VS Code Git API first
+    // Try VS Code Git API first — find the matching repo by root path when possible
     const gitExtension = vscode.extensions.getExtension('vscode.git');
     if (gitExtension) {
       const git = gitExtension.exports.getAPI(1);
       const repositories = git.repositories;
 
       if (repositories.length > 0) {
-        const repo = repositories[0];
+        const targetPath = workspacePath ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+        const repo = targetPath
+          ? repositories.find((r: any) => r.rootUri?.fsPath === targetPath) ?? repositories[0]
+          : repositories[0];
         const branch = repo.state.HEAD?.name;
         if (branch) {
           return branch;
@@ -26,9 +42,8 @@ export async function getCurrentBranch(): Promise<string | undefined> {
     }
 
     // Fallback to command line
-    const workspaceFolders = vscode.workspace.workspaceFolders;
-    if (workspaceFolders && workspaceFolders.length > 0) {
-      const cwd = workspaceFolders[0].uri.fsPath;
+    const cwd = resolveWorkspaceCwd(workspacePath);
+    if (cwd) {
       const branch = execSync('git branch --show-current', {
         cwd,
         encoding: 'utf8',
@@ -44,14 +59,15 @@ export async function getCurrentBranch(): Promise<string | undefined> {
 /**
  * Get recent Git branches
  */
-export async function getRecentBranches(limit: number = 10): Promise<string[]> {
+export async function getRecentBranches(
+  limit: number = 10,
+  workspacePath?: string
+): Promise<string[]> {
   try {
-    const workspaceFolders = vscode.workspace.workspaceFolders;
-    if (!workspaceFolders || workspaceFolders.length === 0) {
+    const cwd = resolveWorkspaceCwd(workspacePath);
+    if (!cwd) {
       return [];
     }
-
-    const cwd = workspaceFolders[0].uri.fsPath;
 
     // Get recent branches sorted by commit date
     const branches = execSync(
@@ -99,16 +115,15 @@ export async function branchExistsOnRemote(branch: string): Promise<boolean> {
 }
 
 /**
- * Get repository information
+ * Get repository information for a specific workspace path (or the first workspace folder).
  */
-export async function getRepositoryInfo(): Promise<GitRepositoryInfo | null> {
+export async function getRepositoryInfo(workspacePath?: string): Promise<GitRepositoryInfo | null> {
   try {
-    const workspaceFolders = vscode.workspace.workspaceFolders;
-    if (!workspaceFolders || workspaceFolders.length === 0) {
+    const rootPath = resolveWorkspaceCwd(workspacePath);
+    if (!rootPath) {
       return null;
     }
 
-    const rootPath = workspaceFolders[0].uri.fsPath;
     const cwd = rootPath;
 
     // Get remote URL
@@ -128,10 +143,10 @@ export async function getRepositoryInfo(): Promise<GitRepositoryInfo | null> {
     const name = match[2];
 
     // Get current branch
-    const currentBranch = await getCurrentBranch();
+    const currentBranch = await getCurrentBranch(rootPath);
 
     // Get recent branches
-    const recentBranches = await getRecentBranches();
+    const recentBranches = await getRecentBranches(10, rootPath);
 
     return {
       owner,
@@ -144,6 +159,39 @@ export async function getRepositoryInfo(): Promise<GitRepositoryInfo | null> {
     console.error('Failed to get repository info:', error);
     return null;
   }
+}
+
+/**
+ * Get repo info for every workspace folder that is a GitHub-backed git repo.
+ */
+export async function getAllWorkspaceRepos(): Promise<WorkspaceRepoInfo[]> {
+  const folders = vscode.workspace.workspaceFolders;
+  if (!folders || folders.length === 0) {
+    return [];
+  }
+
+  const results: WorkspaceRepoInfo[] = [];
+  for (const folder of folders) {
+    try {
+      const repoInfo = await getRepositoryInfo(folder.uri.fsPath);
+      results.push({
+        folderName: folder.name,
+        folderPath: folder.uri.fsPath,
+        owner: repoInfo?.owner ?? null,
+        repoName: repoInfo?.name ?? null,
+        isGitHub: repoInfo !== null,
+      });
+    } catch {
+      results.push({
+        folderName: folder.name,
+        folderPath: folder.uri.fsPath,
+        owner: null,
+        repoName: null,
+        isGitHub: false,
+      });
+    }
+  }
+  return results;
 }
 
 /**

--- a/src/utils/git-operations.ts
+++ b/src/utils/git-operations.ts
@@ -4,15 +4,21 @@
 import { execSync } from 'child_process';
 import * as vscode from 'vscode';
 import type { GitRepositoryInfo, WorkspaceRepoInfo } from '../types/workflow-types';
+import { getActiveWorkspacePath } from './active-workspace';
 
 /**
  * Resolve the working directory for git operations.
  * If workspacePath is provided, uses it directly; otherwise falls back to the
- * first workspace folder.
+ * workspace selected in the sidebar (multi-workspace support), and finally to
+ * the first workspace folder.
  */
 function resolveWorkspaceCwd(workspacePath?: string): string | undefined {
   if (workspacePath) {
     return workspacePath;
+  }
+  const active = getActiveWorkspacePath();
+  if (active) {
+    return active;
   }
   const folders = vscode.workspace.workspaceFolders;
   return folders && folders.length > 0 ? folders[0].uri.fsPath : undefined;
@@ -30,7 +36,7 @@ export async function getCurrentBranch(workspacePath?: string): Promise<string |
       const repositories = git.repositories;
 
       if (repositories.length > 0) {
-        const targetPath = workspacePath ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+        const targetPath = resolveWorkspaceCwd(workspacePath);
         const repo = targetPath
           ? repositories.find((r: any) => r.rootUri?.fsPath === targetPath) ?? repositories[0]
           : repositories[0];
@@ -94,12 +100,10 @@ export async function getRecentBranches(
  */
 export async function branchExistsOnRemote(branch: string): Promise<boolean> {
   try {
-    const workspaceFolders = vscode.workspace.workspaceFolders;
-    if (!workspaceFolders || workspaceFolders.length === 0) {
+    const cwd = resolveWorkspaceCwd();
+    if (!cwd) {
       return false;
     }
-
-    const cwd = workspaceFolders[0].uri.fsPath;
 
     // Check if branch exists on origin
     execSync(`git ls-remote --heads origin ${branch}`, {

--- a/src/utils/repository-config.ts
+++ b/src/utils/repository-config.ts
@@ -9,9 +9,10 @@ const MANUAL_OWNER_KEY = 'githubWorkflowRunner.repository.manualOwner';
 const MANUAL_NAME_KEY = 'githubWorkflowRunner.repository.manualName';
 
 /**
- * Get repository configuration with auto-detection and manual override support
+ * Get repository configuration with auto-detection and manual override support.
+ * When workspacePath is provided, auto-detection targets that specific folder.
  */
-export async function getRepositoryConfig(): Promise<RepositoryConfig> {
+export async function getRepositoryConfig(workspacePath?: string): Promise<RepositoryConfig> {
   const config = vscode.workspace.getConfiguration();
 
   // Check for manual overrides in workspace settings
@@ -19,7 +20,7 @@ export async function getRepositoryConfig(): Promise<RepositoryConfig> {
   const manualName = config.get<string>(MANUAL_NAME_KEY);
 
   // Try to auto-detect repository info
-  const autoDetected = await getRepositoryInfo();
+  const autoDetected = await getRepositoryInfo(workspacePath);
 
   // If manual values are set, use them
   if (manualOwner && manualName) {

--- a/src/utils/workflow-parser.ts
+++ b/src/utils/workflow-parser.ts
@@ -18,7 +18,8 @@ import type {
 export async function parseWorkflowFile(
   filepath: string,
   includeNonDispatch = false,
-  contentOverride?: string
+  contentOverride?: string,
+  workspacePath?: string
 ): Promise<WorkflowDefinition | null> {
   try {
     const content = contentOverride ?? fs.readFileSync(filepath, 'utf8');
@@ -73,7 +74,8 @@ export async function parseWorkflowFile(
     const detectedInputs = detectFilePathParameters(inputs);
 
     // Determine workspace-relative path for file (normalize to forward slashes)
-    const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    const workspaceRoot =
+      workspacePath ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
     const relativeFilepath = workspaceRoot ? path.relative(workspaceRoot, filepath) : filepath;
     const normalizedFilepath = relativeFilepath.split(path.sep).join('/');
 
@@ -117,14 +119,19 @@ function normalizeInputType(type: string | undefined): WorkflowInputType {
 /**
  * Get all workflow files from .github/workflows directory
  */
-export async function getWorkflowFiles(): Promise<string[]> {
+export async function getWorkflowFiles(workspacePath?: string): Promise<string[]> {
   try {
-    const workspaceFolders = vscode.workspace.workspaceFolders;
-    if (!workspaceFolders || workspaceFolders.length === 0) {
+    const root =
+      workspacePath ??
+      (vscode.workspace.workspaceFolders?.length
+        ? vscode.workspace.workspaceFolders[0].uri.fsPath
+        : undefined);
+
+    if (!root) {
       return [];
     }
 
-    const workflowsDir = path.join(workspaceFolders[0].uri.fsPath, '.github', 'workflows');
+    const workflowsDir = path.join(root, '.github', 'workflows');
 
     if (!fs.existsSync(workflowsDir)) {
       return [];
@@ -146,10 +153,11 @@ export async function getWorkflowFiles(): Promise<string[]> {
  * Parse all workflow files and return those with workflow_dispatch
  */
 export async function getAllWorkflowDefinitions(
-  excludePatterns: string[] = []
+  excludePatterns: string[] = [],
+  workspacePath?: string
 ): Promise<WorkflowDefinition[]> {
   try {
-    const workflowFiles = await getWorkflowFiles();
+    const workflowFiles = await getWorkflowFiles(workspacePath);
     const definitions: WorkflowDefinition[] = [];
 
     for (const filepath of workflowFiles) {
@@ -180,14 +188,22 @@ export async function getAllWorkflowDefinitions(
 /**
  * Get a specific workflow definition by filename
  */
-export async function getWorkflowDefinition(filename: string): Promise<WorkflowDefinition | null> {
+export async function getWorkflowDefinition(
+  filename: string,
+  workspacePath?: string
+): Promise<WorkflowDefinition | null> {
   try {
-    const workspaceFolders = vscode.workspace.workspaceFolders;
-    if (!workspaceFolders || workspaceFolders.length === 0) {
+    const root =
+      workspacePath ??
+      (vscode.workspace.workspaceFolders?.length
+        ? vscode.workspace.workspaceFolders[0].uri.fsPath
+        : undefined);
+
+    if (!root) {
       return null;
     }
 
-    const filepath = path.join(workspaceFolders[0].uri.fsPath, '.github', 'workflows', filename);
+    const filepath = path.join(root, '.github', 'workflows', filename);
 
     if (!fs.existsSync(filepath)) {
       return null;
@@ -196,10 +212,10 @@ export async function getWorkflowDefinition(filename: string): Promise<WorkflowD
     // Prefer unsaved in-memory content when the workflow file is open.
     const openDoc = vscode.workspace.textDocuments.find((doc) => doc.uri.fsPath === filepath);
     if (openDoc) {
-      return await parseWorkflowFile(filepath, false, openDoc.getText());
+      return await parseWorkflowFile(filepath, false, openDoc.getText(), workspacePath);
     }
 
-    return await parseWorkflowFile(filepath);
+    return await parseWorkflowFile(filepath, false, undefined, workspacePath);
   } catch (error) {
     console.error(`Failed to get workflow definition for ${filename}:`, error);
     return null;

--- a/src/utils/workflow-parser.ts
+++ b/src/utils/workflow-parser.ts
@@ -11,6 +11,7 @@ import type {
   WorkflowInputType,
   WorkflowJobDefinition,
 } from '../types/workflow-types';
+import { getActiveWorkspacePath } from './active-workspace';
 
 /**
  * Parse a single workflow file
@@ -75,7 +76,7 @@ export async function parseWorkflowFile(
 
     // Determine workspace-relative path for file (normalize to forward slashes)
     const workspaceRoot =
-      workspacePath ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+      workspacePath ?? getActiveWorkspacePath() ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
     const relativeFilepath = workspaceRoot ? path.relative(workspaceRoot, filepath) : filepath;
     const normalizedFilepath = relativeFilepath.split(path.sep).join('/');
 
@@ -123,6 +124,7 @@ export async function getWorkflowFiles(workspacePath?: string): Promise<string[]
   try {
     const root =
       workspacePath ??
+      getActiveWorkspacePath() ??
       (vscode.workspace.workspaceFolders?.length
         ? vscode.workspace.workspaceFolders[0].uri.fsPath
         : undefined);
@@ -195,6 +197,7 @@ export async function getWorkflowDefinition(
   try {
     const root =
       workspacePath ??
+      getActiveWorkspacePath() ??
       (vscode.workspace.workspaceFolders?.length
         ? vscode.workspace.workspaceFolders[0].uri.fsPath
         : undefined);
@@ -406,20 +409,21 @@ export async function getAllWorkflowDefinitionsIncludingNonDispatch(
  */
 export async function parseJobDependencies(workflowPath: string): Promise<WorkflowJobDefinition[]> {
   try {
-    const workspaceFolders = vscode.workspace.workspaceFolders;
-    if (!workspaceFolders || workspaceFolders.length === 0) {
+    const workspaceRoot =
+      getActiveWorkspacePath() ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    if (!workspaceRoot) {
       return [];
     }
 
     // Handle both absolute and relative paths
     let filepath = workflowPath;
     if (!path.isAbsolute(workflowPath)) {
-      filepath = path.join(workspaceFolders[0].uri.fsPath, workflowPath);
+      filepath = path.join(workspaceRoot, workflowPath);
     }
 
     // Also check if the path starts with .github/workflows
     if (!fs.existsSync(filepath) && !workflowPath.startsWith('.github')) {
-      filepath = path.join(workspaceFolders[0].uri.fsPath, '.github', 'workflows', workflowPath);
+      filepath = path.join(workspaceRoot, '.github', 'workflows', workflowPath);
     }
 
     if (!fs.existsSync(filepath)) {

--- a/webview/Sidebar.svelte
+++ b/webview/Sidebar.svelte
@@ -12,6 +12,7 @@
     RecentFile,
     ParsedFileContent,
     FileContentConfig,
+    WorkspaceRepoInfo,
   } from '../src/types/workflow-types';
   import SmartFileInput from './components/SmartFileInput.svelte';
   import FileContentModal from './components/FileContentModal.svelte';
@@ -21,8 +22,14 @@
   let filteredWorkflows: WorkflowDefinition[] = [];
   let searchQuery = '';
   let selectedWorkflow: WorkflowDefinition | null = null;
+
+  // Multi-workspace state
+  let workspaceFolders: WorkspaceRepoInfo[] = [];
+  let activeWorkspacePath: string | null = null;
+  $: isMultiWorkspace = workspaceFolders.length > 1;
   let branch = '';
   let currentBranch: string | null = null; // Current local Git branch
+  let recentBranches: string[] = [];
   const WAVE_ANIMATION_MIN_INTERVAL_MS = 60_000;
   const SIDEBAR_WAVE_STORAGE_KEY = 'githubWorkflowRunner:sidebarWaveLastTime';
   let showWelcomeWave = false;
@@ -424,6 +431,22 @@
 
   function showStorageInfo() {
     vscode.postMessage({ type: 'getStorageInfo' });
+  }
+
+  function selectWorkspace(folderPath: string) {
+    if (folderPath === (activeWorkspacePath ?? '')) {
+      return;
+    }
+    // Reset workflow state — the new workspace will send fresh data
+    selectedWorkflow = null;
+    searchQuery = '';
+    workflows = [];
+    filteredWorkflows = [];
+    branch = '';
+    recentBranches = [];
+    inputs = {};
+    activeWorkspacePath = folderPath;
+    vscode.postMessage({ type: 'setActiveWorkspace', data: folderPath });
   }
 
   /**
@@ -907,6 +930,9 @@
     // Check authentication status first
     vscode.postMessage({ type: 'checkAuth' });
 
+    // Request workspace folders for repo switcher
+    vscode.postMessage({ type: 'getWorkspaceFolders' });
+
     // Load favorites on mount
     vscode.postMessage({ type: 'getFavorites' });
     vscode.postMessage({ type: 'getRepositoryFavorites' });
@@ -950,6 +976,13 @@
         showConfirmModal = true;
         break;
       }
+
+      case 'getWorkspaceFolders':
+        if (message.success) {
+          workspaceFolders = message.data.workspaces as WorkspaceRepoInfo[];
+          activeWorkspacePath = message.data.activeWorkspacePath as string | null;
+        }
+        break;
 
       case 'getWorkflows':
         if (message.success) {
@@ -1042,6 +1075,12 @@
       case 'getDefaultBranch':
         if (message.success && message.data) {
           defaultBranch = String(message.data ?? '').trim();
+        }
+        break;
+
+      case 'getRecentBranches':
+        if (message.success && Array.isArray(message.data)) {
+          recentBranches = message.data;
         }
         break;
 
@@ -2733,12 +2772,27 @@
           <span class="repo-info-label">
             <span class="codicon codicon-repo"></span>
           </span>
-          <span
-            class="repo-info-value"
-            title={repoOwner && repoName ? `${repoOwner}/${repoName}` : 'Repository not configured'}
-          >
-            {repoName || '(not configured)'}
-          </span>
+          {#if isMultiWorkspace}
+            <select
+              class="repo-info-value repo-switcher-inline"
+              value={activeWorkspacePath ?? workspaceFolders[0]?.folderPath ?? ''}
+              title={repoOwner && repoName ? `${repoOwner}/${repoName}` : 'Select workspace'}
+              on:change={(e) => selectWorkspace((e.target as HTMLSelectElement).value)}
+            >
+              {#each workspaceFolders as ws (ws.folderPath)}
+                <option value={ws.folderPath}>
+                  {ws.isGitHub && ws.repoName ? ws.repoName : ws.folderName}
+                </option>
+              {/each}
+            </select>
+          {:else}
+            <span
+              class="repo-info-value"
+              title={repoOwner && repoName ? `${repoOwner}/${repoName}` : 'Repository not configured'}
+            >
+              {repoName || '(not configured)'}
+            </span>
+          {/if}
         </div>
         <div class="repo-info-row">
           <span class="repo-info-label" title="Local Git branch">
@@ -3022,11 +3076,20 @@
             <input
               id="branch"
               type="text"
+              list="branch-suggestions"
               bind:value={branch}
               on:input={clearError}
               placeholder="e.g., develop, main"
               disabled={loading}
+              autocomplete="off"
             />
+            {#if recentBranches.length > 0}
+              <datalist id="branch-suggestions">
+                {#each [...new Set([...(defaultBranch ? [defaultBranch] : []), ...(currentBranch ? [currentBranch] : []), ...recentBranches])] as b (b)}
+                  <option value={b}></option>
+                {/each}
+              </datalist>
+            {/if}
             {#if defaultBranch}
               <button
                 type="button"
@@ -5494,6 +5557,27 @@
   }
 
   /* Section Header with Help Button */
+  /* Inline repo switcher inside the Git Context box */
+  .repo-switcher-inline {
+    background: transparent;
+    border: none;
+    color: inherit;
+    font-size: inherit;
+    font-family: inherit;
+    padding: 0;
+    margin: 0;
+    cursor: pointer;
+    appearance: auto;
+    flex: 1;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .repo-switcher-inline:focus {
+    outline: 1px solid var(--vscode-focusBorder);
+    border-radius: 2px;
+  }
+
   .section-header {
     display: flex;
     align-items: center;

--- a/webview/WorkflowRuns.svelte
+++ b/webview/WorkflowRuns.svelte
@@ -800,6 +800,12 @@
         // Also clear watched runs as they are repository-specific
         watchedRuns = new Set();
         showWatchedOnly = false;
+        // The workflow dropdown is built from the previous repository's local
+        // workflow definitions. Drop them and re-request the new repository's
+        // workflows so the "All workflows" list reflects the active repo only.
+        allWorkflowDefinitions = [];
+        buildAvailableWorkflows();
+        vscode.postMessage({ type: 'getWorkflows' });
       }
     }
     previousRepository = repository ? { owner: repository.owner, name: repository.name } : null;


### PR DESCRIPTION
## Summary

- **Multi-workspace support:** When VS Code is open with multiple workspace folders, a repo switcher appears inside the Git Context box. Clicking the repo name shows a dropdown of all available workspaces. Switching reloads workflows, branches, and repository config for the selected folder.
- **Branch suggestions dropdown:** The Branch field now shows a native autocomplete list after selecting a workflow. Suggestions include the default branch, current local branch, and recently used branches — deduplicated and ordered by relevance. The field remains free-text.

## Changes

### New
- `WorkspaceRepoInfo` type — represents a workspace folder and its GitHub repo metadata
- `getAllWorkspaceRepos()` in `git-operations.ts` — enumerates all workspace folders with their git info
- `getWorkspaceFolders` / `setActiveWorkspace` message handlers in `SidebarProvider`
- Inline `<select>` repo switcher in the Git Context box (hidden when only one workspace)
- `recentBranches` state + `getRecentBranches` message handler in `Sidebar.svelte`
- Branch `<input>` now paired with a `<datalist>` for autocomplete suggestions

### Modified
- `git-operations.ts`, `workflow-parser.ts`, `repository-config.ts`, `git-context-validation.ts` — all key functions now accept an optional `workspacePath` parameter so operations target the active workspace instead of always defaulting to `workspaceFolders[0]`
- `SidebarProvider` — `_activeWorkspacePath` threaded through all data-fetching calls

## Test plan

- [ ] Single workspace: no visual change, repo switcher hidden
- [ ] Multi-root workspace: repo switcher visible in Git Context box; switching reloads workflows and branches correctly
- [ ] Branch field shows suggestions after selecting a workflow
- [ ] All existing tests pass (`npm test`)